### PR TITLE
Webhook mapping for PokeAlarm support

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -327,6 +327,27 @@ MINIMUM_SCORE = 0.4  # the required score after FULL_TIME seconds have passed
 
 #WEBHOOKS = {'http://127.0.0.1:4000'}
 
+# Webhook formatting config
+
+#WEBHOOK_RAID_MAPPING = {}
+
+# Allows configuration of outgoing raid webhooks.
+# Defines <our field name>:<recipient's field name>
+# Add only the necessary fields.
+#
+# E.g. For PokeAlarm, add the following config.
+#WEBHOOK_RAID_MAPPING = {
+#    'external_id': 'raid_seed',
+#    'gym_name': 'name',
+#    'gym_url': 'url',
+#}
+
+# The following are all the available fields for raid webhook.
+#   "external_id", "latitude", "longitude", "level", "pokemon_id",
+#   "team", "cp", "move_1", "move_2",
+#   "raid_begin", "raid_battle", "raid_end",
+#   "gym_name", "gym_url"
+
 
 ##### Referencing landmarks in your tweets/notifications
 

--- a/config.example.py
+++ b/config.example.py
@@ -327,26 +327,29 @@ MINIMUM_SCORE = 0.4  # the required score after FULL_TIME seconds have passed
 
 #WEBHOOKS = {'http://127.0.0.1:4000'}
 
-# Webhook formatting config
-
-#WEBHOOK_RAID_MAPPING = {}
-
-# Allows configuration of outgoing raid webhooks.
-# Defines <our field name>:<recipient's field name>
-# Add only the necessary fields.
-#
-# E.g. For PokeAlarm, add the following config.
+#####
+## Webhook formatting config
+##
+## Allows configuration of outgoing raid webhooks.
+## Defines <our field name>:<recipient's field name>
+##
+## The following are all the available fields for raid webhook.
+##   "external_id", "latitude", "longitude", "level", "pokemon_id",
+##   "team", "cp", "move_1", "move_2",
+##   "raid_begin", "raid_battle", "raid_end",
+##   "gym_name", "gym_url"
+##
+## For PokeAlarm, add the following config.
+####
 #WEBHOOK_RAID_MAPPING = {
 #    'external_id': 'raid_seed',
 #    'gym_name': 'name',
 #    'gym_url': 'url',
 #}
 
-# The following are all the available fields for raid webhook.
-#   "external_id", "latitude", "longitude", "level", "pokemon_id",
-#   "team", "cp", "move_1", "move_2",
-#   "raid_begin", "raid_battle", "raid_end",
-#   "gym_name", "gym_url"
+# For others, this is the default value (no mapping defined)
+#WEBHOOK_RAID_MAPPING = {}
+
 
 
 ##### Referencing landmarks in your tweets/notifications

--- a/config.example.py
+++ b/config.example.py
@@ -115,7 +115,7 @@ SPIN_COOLDOWN = 300    # spin only one PokéStop every n seconds (default 300)
 ## Gyms
 
 # Cools down for x seconds for a worker after scanning a gym details.
-#GYM_COOLDOWN = 180
+#GYM_COOLDOWN = 10
 
 # Toggles scanning for gym details. Smart throttle is applied in the same way as PokéStops.
 #GET_GYM_DETAILS = False

--- a/monocle/db.py
+++ b/monocle/db.py
@@ -902,11 +902,11 @@ def get_pokemon_ranking(session):
     none_seen = [x for x in range(1,252) if x not in ranked]
     return none_seen + ranked
 
-def get_gym_name(session,raw_fort):
+def get_gym(session,raw_fort):
     fort = session.query(Fort) \
         .filter(Fort.external_id == raw_fort['external_id']) \
         .first()
-    return fort.name
+    return fort
 
 def get_sightings_per_pokemon(session):
     query = session.query(Sighting.pokemon_id, func.count(Sighting.pokemon_id).label('how_many')) \

--- a/monocle/notification.py
+++ b/monocle/notification.py
@@ -704,7 +704,10 @@ class Notifier:
             score_required = self.get_required_score(now)
 
         try:
-            iv_score = (pokemon['individual_attack'] + pokemon['individual_defense'] + pokemon['individual_stamina']) / 45
+            if score_required > 0:
+                iv_score = (pokemon['individual_attack'] + pokemon['individual_defense'] + pokemon['individual_stamina']) / 45
+            else:
+                iv_score = None
         except KeyError:
             if conf.IGNORE_IVS:
                 iv_score = None
@@ -773,12 +776,12 @@ class Notifier:
     async def notify_raid(self, raid, fort, time_of_day):
         with session_scope() as session:
             gym = get_gym(session,fort)
-        if gym:
-            gym_name = gym.name
-            gym_url = gym.url
-        else:
-            gym_name = None
-            gym_url = None
+            if gym:
+                gym_name = gym.name
+                gym_url = gym.url
+            else:
+                gym_name = None
+                gym_url = None
         pokemon = {
             'raid': True,
             'pokemon_id': raid['pokemon_id'],
@@ -817,20 +820,20 @@ class Notifier:
             data = {
                 'type': "raid",
                 'message': {
-                    w.get("external_id", "external_id"): pokemon['external_id'],
-                    w.get("latitude", "latitude"): pokemon['lat'],
-                    w.get("longitude", "longitude"): pokemon['lon'],
-                    w.get("level", "level"): pokemon['level'],
-                    w.get("pokemon_id", "pokemon_id"): pokemon['pokemon_id'],
-                    w.get("team", "team"): pokemon['team'],
-                    w.get("cp", "cp"): pokemon['cp'],
-                    w.get("move_1", "move_1"): pokemon['move_1'],
-                    w.get("move_2", "move_2"): pokemon['move_2'],
-                    w.get("raid_begin", "raid_begin"): pokemon['time_spawn'],
-                    w.get("raid_battle", "raid_battle"): pokemon['time_battle'],
-                    w.get("raid_end", "raid_end"): pokemon['time_end'],
-                    w.get("gym_name", "gym_name"): pokemon.get('gym_name'),
-                    w.get("gym_url", "gym_url"): pokemon.get('gym_url'),
+                    m.get("external_id", "external_id"): pokemon['external_id'],
+                    m.get("latitude", "latitude"): pokemon['lat'],
+                    m.get("longitude", "longitude"): pokemon['lon'],
+                    m.get("level", "level"): pokemon['level'],
+                    m.get("pokemon_id", "pokemon_id"): pokemon['pokemon_id'],
+                    m.get("team", "team"): pokemon['team'],
+                    m.get("cp", "cp"): pokemon['cp'],
+                    m.get("move_1", "move_1"): pokemon['move_1'],
+                    m.get("move_2", "move_2"): pokemon['move_2'],
+                    m.get("raid_begin", "raid_begin"): pokemon['time_spawn'],
+                    m.get("raid_battle", "raid_battle"): pokemon['time_battle'],
+                    m.get("raid_end", "raid_end"): pokemon['time_end'],
+                    m.get("gym_name", "gym_name"): pokemon.get('gym_name'),
+                    m.get("gym_url", "gym_url"): pokemon.get('gym_url'),
                 }
             }
         else:

--- a/monocle/sanitized.py
+++ b/monocle/sanitized.py
@@ -139,7 +139,8 @@ _valid_types = {
     'TWITTER_SCREEN_NAME': str,
     'TZ_OFFSET': Number,
     'UVLOOP': bool,
-    'WEBHOOKS': set_sequence
+    'WEBHOOKS': set_sequence,
+    'WEBHOOK_RAID_MAPPING': dict, 
 }
 
 _defaults = {
@@ -256,7 +257,8 @@ _defaults = {
     'TWITTER_SCREEN_NAME': None,
     'TZ_OFFSET': None,
     'UVLOOP': True,
-    'WEBHOOKS': None
+    'WEBHOOKS': None,
+    'WEBHOOK_RAID_MAPPING': {},
 }
 
 

--- a/monocle/sanitized.py
+++ b/monocle/sanitized.py
@@ -239,7 +239,7 @@ _defaults = {
     'SPEED_UNIT': 'miles',
     'SPIN_COOLDOWN': 300,
     'SPIN_POKESTOPS': True,
-    'GYM_COOLDOWN': 180,
+    'GYM_COOLDOWN': 10,
     'GET_GYM_DETAILS': False,
     'STAT_REFRESH': 5,
     'STAY_WITHIN_MAP': True,

--- a/monocle/worker.py
+++ b/monocle/worker.py
@@ -883,7 +883,7 @@ class Worker:
                             normalized_raid = self.normalize_raid(fort)
                             if (notify_conf and normalized_raid['pokemon_id'] > 0
                                     and normalized_raid['time_end'] > int(time())):
-                                LOOP.create_task(self.notifier.notify_raid(normalized_raid, normalized_fort, map_objects.time_of_day))
+                                LOOP.create_task(self.notifier.webhook_raid(normalized_raid, normalized_fort))
                             db_proc.add(normalized_raid)
 
             if more_points:


### PR DESCRIPTION
Add this in `monocle/config.py`.

```
WEBHOOK_RAID_MAPPING = {
    'external_id': 'raid_seed',
    'gym_name': 'name',
    'gym_url': 'url',
}
```

Unfortunately, gym name and url are not yet supported for raids in PA. I put it there in a hope that they will be implemented by PA soon.

See wiki for details.
https://github.com/MonkeyTedBaker/Monocle/wiki/Webhook-adapter-(raids-with-PokeAlarm)