### PR TITLE
Get eggs sent to webhook and fix player level null issue

### DIFF
--- a/monocle/worker.py
+++ b/monocle/worker.py
@@ -1076,7 +1076,7 @@ class Worker:
                 inventory_items = responses['GET_INVENTORY'].inventory_delta.inventory_items
                 for item in inventory_items:
                     level = item.inventory_item_data.player_stats.level
-                    if level and level > self.player_level:
+                    if level and self.player_level and level > self.player_level:
                         # level_up_rewards if level has changed
                         request = self.api.create_request()
                         request.level_up_rewards(level=level)

--- a/monocle/worker.py
+++ b/monocle/worker.py
@@ -884,8 +884,7 @@ class Worker:
                     if fort.HasField('raid_info'):
                         if fort not in RAID_CACHE:
                             normalized_raid = self.normalize_raid(fort)
-                            if (notify_conf and normalized_raid['pokemon_id'] > 0
-                                    and normalized_raid['time_end'] > int(time())):
+                            if (notify_conf and normalized_raid['time_end'] > int(time())):
                                 LOOP.create_task(self.notifier.webhook_raid(normalized_raid, normalized_fort))
                             db_proc.add(normalized_raid)
 


### PR DESCRIPTION
Getting a lot of these errors:

[2017-09-07 19:06:31][   ERROR][worker-1870] A wild TypeError appeared!
Traceback (most recent call last):
  File "/home/scanbot/MonocleHC/monocle/worker.py", line 670, in visit
    return await self.visit_point(point, spawn_id, bootstrap)
  File "/home/scanbot/MonocleHC/monocle/worker.py", line 866, in visit_point
    await self.spin_pokestop(fort)
  File "/home/scanbot/MonocleHC/monocle/worker.py", line 1076, in spin_pokestop
    if level and level > self.player_level:
TypeError: '>' not supported between instances of 'int' and 'NoneType'

Given level is already checked for type, it must be the player level that is the issue. Not sure player level is not known or gotten, but adding this check on self.player_level not being null has fixed my errors.