### PR TITLE
Allow for round robin of PGScout endpoints

### DIFF
--- a/monocle/sanitized.py
+++ b/monocle/sanitized.py
@@ -94,7 +94,7 @@ _valid_types = {
     'PASS': str,
     'PB_API_KEY': str,
     'PB_CHANNEL': int,
-    'PGSCOUT_ENDPOINT': str,
+    'PGSCOUT_ENDPOINT': set_sequence,
     'PGSCOUT_TIMEOUT': int,
     'PLAYER_LOCALE': dict,
     'PROVIDER': str,

--- a/monocle/worker.py
+++ b/monocle/worker.py
@@ -86,6 +86,9 @@ class Worker:
     if conf.NOTIFY or conf.NOTIFY_RAIDS or conf.NOTIFY_RAIDS_WEBHOOK:
         notifier = Notifier()
 
+    if conf.PGSCOUT_ENDPOINT:
+	    PGScout_cycle=cycle(conf.PGSCOUT_ENDPOINT)
+
     def __init__(self, worker_no):
         self.worker_no = worker_no
         self.log = get_logger('worker-{}'.format(worker_no))
@@ -946,9 +949,10 @@ class Worker:
 
 
     async def pgscout(self, session, pokemon, spawn_id):
-        try:
+        PGScout_address=next(self.PGScout_cycle)
+		try:
             async with session.get(
-                    conf.PGSCOUT_ENDPOINT,
+                    PGScout_address,
                     params={'pokemon_id': pokemon['pokemon_id'],
                             'encounter_id': pokemon['encounter_id'],
                             'spawn_point_id': spawn_id,


### PR DESCRIPTION
Just as it reads above.  You can set multiple PGScout endpoints in your config using the same format as webhooks or proxies (PGSCOUT_ENDPOINT = {'http://1.2.3.4:123/iv', 'http://2.3.4.5:234/iv', ....}