### PR TITLE
Add Scanned Gym Names to Default Monocle Front End Markers

### DIFF
--- a/monocle/db.py
+++ b/monocle/db.py
@@ -934,6 +934,7 @@ def _get_forts(session):
             fs.last_modified,
             f.lat,
             f.lon,
+            f.name,
             fs.slots_available
         FROM fort_sightings fs
         JOIN forts f ON f.id=fs.fort_id

--- a/monocle/db.py
+++ b/monocle/db.py
@@ -912,6 +912,7 @@ def _get_forts_sqlite(session):
             fs.last_modified,
             f.lat,
             f.lon,
+            f.name,
             fs.slots_available
         FROM fort_sightings fs
         JOIN forts f ON f.id=fs.fort_id

--- a/monocle/static/js/main.js
+++ b/monocle/static/js/main.js
@@ -248,7 +248,7 @@ function FortMarker (raw) {
                        '<br>Slots occupied: '+ (6 - raw.slots_available) + '/6' +
                        '<br>Guarding Pokemon: ' + raw.pokemon_name + ' (#' + raw.pokemon_id + ')';
         }
-	content += '<br>Gym Name: ' + raw.gym_name;
+        content += '<br>Gym Name: ' + raw.gym_name;
         content += '<br>=&gt; <a href=https://www.google.com/maps/?daddr='+ raw.lat + ','+ raw.lon +' target="_blank" title="See in Google Maps">Get directions</a>';
         event.popup.setContent(content);
     });

--- a/monocle/static/js/main.js
+++ b/monocle/static/js/main.js
@@ -248,6 +248,7 @@ function FortMarker (raw) {
                        '<br>Slots occupied: '+ (6 - raw.slots_available) + '/6' +
                        '<br>Guarding Pokemon: ' + raw.pokemon_name + ' (#' + raw.pokemon_id + ')';
         }
+	content += '<br>Gym Name: ' + raw.gym_name;
         content += '<br>=&gt; <a href=https://www.google.com/maps/?daddr='+ raw.lat + ','+ raw.lon +' target="_blank" title="See in Google Maps">Get directions</a>';
         event.popup.setContent(content);
     });

--- a/monocle/web_utils.py
+++ b/monocle/web_utils.py
@@ -167,7 +167,8 @@ def get_gym_markers(names=POKEMON):
             'lat': fort['lat'],
             'lon': fort['lon'],
             'slots_available': fort['slots_available'],
-            'last_modified': fort['last_modified']
+            'last_modified': fort['last_modified'],
+            'gym_name': fort['name']
     } for fort in forts]
 
 


### PR DESCRIPTION
A couple simple edits to add gym names to default front end markers. If the gym name has not been scanned, it will display as: "Gym Name: null:"